### PR TITLE
fix: force typscript to emit import

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+quote_type = single
+
+[*.{js,json,proto,ts}]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -2,7 +2,7 @@ name: semantic-release
 
 on:
   push:
-    branches: [main]
+    branches: [main2]
 
 jobs:
   semantic:

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "arrowParens": "always",
+  "trailingComma": "all",
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,19 @@
 So, I got this crazy idea of making every class, property and method emitted through reflect-metadata when compiling a trypescript code.
 Long story short I did some research and didn't find a good solution, but figured out that I could use **nest build**, of [@nestjs/cli](https://github.com/nestjs/nest-cli), to manipulate the code before compiling it, so I did.
 
-This is a working in progress, though. The solution is not production ready and I'll list the issues I know, but if you want to test it out:
+This is a working in progress, though, and I'd love to get some suggestions or contributions.
+
+## But why?
+
+There're some situations where having access to every class metadata during runtime is quite useful. Let's say you have an application separated in layers: domain, application, infrastructure, and so son, but you fill up your domain with nestjs, inversify, or tsyringe decorators, or even mongoose, but you want to do a external reference free domain layer. If you have the metadata, it's possible to create all these classes decorations programmatically at infrastructure layer!
+
+Let's say you're using @nestjs/swagger, and you have to put in every property the @ApiProperty decorator, even though you don't specify nothing special. Having all de metadata emitted, you can create a decorator where you just decorate the class, and automatizes the decoration of all the properties!
+
+## How to use it?
+
+As I said, this is a @nestjs/cli plugin, so you need to use nest build to compile your solution. There's no problem if you're not using nestjs in anything else, the nest build can be used stand alone.
+
+Now, to use this plugin, do the following steps:
 
 * Add the plugin in the **.nest-cli.json**
 ```json

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -1,46 +1,123 @@
+/* eslint-disable no-bitwise */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as ts from 'typescript';
 import { TypeScriptBinaryLoader } from './typescript-loader';
 
 const tsBinary = new TypeScriptBinaryLoader().load();
-function isStatic(node: ts.MethodDeclaration | ts.ClassDeclaration | ts.PropertyDeclaration) {
+function isStatic(
+  node: ts.MethodDeclaration | ts.ClassDeclaration | ts.PropertyDeclaration,
+) {
   return node.modifiers?.find((x) => x.kind === ts.SyntaxKind.StaticKeyword);
 }
 
+type TypedNode = Pick<ts.ParameterDeclaration, 'type'>;
+
+type NodeWithParameters = Pick<ts.MethodDeclaration, 'parameters'>;
+
+function addRef(p: TypedNode, imports: Map<any, any>, mustImport: Set<unknown>) {
+  if (p.type) {
+    const ref = imports.get(p.type.getText());
+    if (ref) mustImport.add(ref);
+  }
+}
+
+function addParameterRefs(node: NodeWithParameters, imports: Map<any, any>, mustImport: Set<unknown>) {
+for (const p of node.parameters) {
+  addRef(p, imports, mustImport);
+}
+}
 export function before() {
   return (ctx: ts.TransformationContext): ts.Transformer<any> => {
     return (sf: ts.SourceFile) => {
-      const visitNode = (node: ts.Node): ts.Node => {
+      const imports = new Map();
+      const mustImport = new Set();
+      const visitNode = (node: ts.Node) => {
         try {
-          if ((tsBinary.isMethodDeclaration(node)
-            || tsBinary.isPropertyDeclaration(node)
-            || tsBinary.isClassDeclaration(node))
-            && !tsBinary.getDecorators(node)?.length
-            && !isStatic(node)
+          if (tsBinary.isImportClause(node)) {
+            const { namedBindings } = node;
+            if (namedBindings) {
+              for (const item of ts.isNamedImports(namedBindings)
+                ? namedBindings.elements
+                : []) {
+                imports.set(item.name.getText(), node);
+              }
+            }
+          } else if (
+            (tsBinary.isMethodDeclaration(node) ||
+              tsBinary.isPropertyDeclaration(node) ||
+              tsBinary.isClassDeclaration(node)) &&
+            !tsBinary.getDecorators(node)?.length &&
+            !isStatic(node)
           ) {
             const decorator = tsBinary.factory.createDecorator(
               tsBinary.factory.createCallExpression(
                 tsBinary.factory.createIdentifier('require'),
                 undefined,
                 [
-                  tsBinary.factory.createStringLiteral('nestjs-emitter/dist/simple-decorator'),
-                ]
-              )
+                  tsBinary.factory.createStringLiteral(
+                    'nestjs-emitter/dist/simple-decorator',
+                  ),
+                ],
+              ),
             );
-            node = tsBinary.factory.replaceDecoratorsAndModifiers(
-              node,
-              [...(node.modifiers ?? []), decorator]
-            );
+            if (!tsBinary.isClassDeclaration(node)) {
+              if (node.type) addRef(node, imports, mustImport);
+              if (tsBinary.isMethodDeclaration(node)) {
+                  addParameterRefs(node, imports, mustImport);
+              }
+            } else {
+              for (const member of node.members) {
+                if (tsBinary.isConstructorDeclaration(member)) {
+                  addParameterRefs(member, imports, mustImport);
+                  break;
+                }
+              }
+            }
+            node = tsBinary.factory.replaceDecoratorsAndModifiers(node, [
+              ...(node.modifiers ?? []),
+              decorator,
+            ]);
             return tsBinary.isClassDeclaration(node)
               ? tsBinary.visitEachChild(node, visitNode, ctx)
               : node;
           }
           return tsBinary.visitEachChild(node, visitNode, ctx);
-        } catch {
+        } catch (err) {
+          console.log(err.stack);
           return node;
         }
       };
-      return tsBinary.visitNode(sf, visitNode);
+      const processImports = (node: ts.Node) => {
+        try {
+          if (tsBinary.isImportClause(node) && mustImport.has(node)) {
+            const { namedBindings } = node;
+            if (namedBindings) {
+              // Hack: if a import is flagged as transient and has links.referenced = true,
+              // typescript will be forced to emit its import during transpiling.
+              // Maybe there's a cleaner way to do it.
+              for (const item of ts.isNamedImports(namedBindings)
+                ? namedBindings.elements
+                : []) {
+                (item as any).symbol.flags |= 33554432 /* Transient */;
+                (item as any).symbol.links = { referenced: true };
+                break;
+              }
+            }
+            return tsBinary.factory.updateImportClause(
+              node,
+              false,
+              node.name,
+              node.namedBindings,
+            );
+          }
+          return tsBinary.visitEachChild(node, processImports, ctx);
+        } catch (err) {
+          console.log(err.stack);
+          return node;
+        }
+      };
+      const nodeResult = tsBinary.visitNode(sf, visitNode);
+      return tsBinary.visitNode(nodeResult, processImports);
     };
   };
 }

--- a/src/simple-decorator.ts
+++ b/src/simple-decorator.ts
@@ -1,3 +1,3 @@
 export = function simpleDecorator() {
-    //
+  //
 };


### PR DESCRIPTION
Some metadata emissions refers to class Types but
Typescripts has no clue it has to import its references to make the final code work. This pr adds a hack where we force the transpiler to do so. Maybe there's a better way to do it.